### PR TITLE
 Correctly pass the widget tree to the KeyboardListener so that it wraps the listening area.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,7 @@ class _MyHomePageState extends State<MyHomePage> {
     UnitechBarcodeScanner(),
     BlueBirdBarcodeScanner(),
     ZebraBarcodeScanner('my_profile'),
-    UsbKeyboardScanner(),
+    UsbKeyboardScanner(child: const SizedBox()),
   ];
 
   @override

--- a/packages/usb_keyboard_scanner/README.md
+++ b/packages/usb_keyboard_scanner/README.md
@@ -18,6 +18,8 @@ BarcodeScannerWidget(
   configuration: const ScannerConfiguration(
     enableFormats: {}, // supported formats are determined by the scanner itself
   ),
-  scanners: [UsbKeyboardScanner()],
+  scanners: [UsbKeyboardScanner(
+    child: content, 
+  )],
 );
 ```

--- a/packages/usb_keyboard_scanner/example/main.dart
+++ b/packages/usb_keyboard_scanner/example/main.dart
@@ -63,7 +63,9 @@ class _MyHomePageState extends State<MyHomePage> {
         configuration: const ScannerConfiguration(
           enableFormats: {}, // enableFormats unfortunately does not work with the UsbKeyboardScanner, this configuration is managed by the device itself
         ),
-        scanners: [UsbKeyboardScanner()],
+        scanners: [UsbKeyboardScanner(
+          child: const SizedBox(),
+        )],
       ),
     );
   }

--- a/packages/usb_keyboard_scanner/lib/src/usb_keyboard_scanner.dart
+++ b/packages/usb_keyboard_scanner/lib/src/usb_keyboard_scanner.dart
@@ -8,7 +8,8 @@ import 'package:flutter/material.dart';
 /// Please follow the installation instructions in
 /// [https://pub.dev/packages/fast_barcode_scanner]
 class UsbKeyboardScanner implements BarcodeScanner {
-  int maxCharacterInputIntervalMs;
+  final int maxCharacterInputIntervalMs;
+  final Widget child;
 
   late ValueChanged<BarcodeScanResult> _onScan;
   late FocusNode _focusNode;
@@ -17,7 +18,10 @@ class UsbKeyboardScanner implements BarcodeScanner {
 
   var isRunning = true;
 
-  UsbKeyboardScanner({this.maxCharacterInputIntervalMs = 50});
+  UsbKeyboardScanner({
+    this.maxCharacterInputIntervalMs = 50,
+    required this.child,
+  });
 
   @override
   Widget? buildUI(ScannerConfiguration configuration, BuildContext context) =>
@@ -25,7 +29,7 @@ class UsbKeyboardScanner implements BarcodeScanner {
         focusNode: _focusNode,
         autofocus: true,
         onKeyEvent: _onKeyEvent,
-        child: const SizedBox(),
+        child: child,
       );
 
   @override


### PR DESCRIPTION
Improves: no need to find a place to put BarcodeScannerWidget, adding more complexity into layouts stretching.
Fixes: even properly placed KeyboardListener won't capture keyboard event without a child widget tree (therefore it's required)

Usage:

**Old:**

_Column(children:[
  content,
  barcodeScannerWidget,
])_

**New:**

_BarcodeScannerWidget(children:[
  content,
  scanners: [
    UsbKeyboardScanner(child: content),
  ],
])_